### PR TITLE
Couple convenience links in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # ChemCore
 
+[![Crates.io](https://img.shields.io/crates/v/chemcore)](https://crates.io/crates/chemcore)
+[![Docs](https://docs.rs/chemcore/badge.svg)](https://docs.rs/chemcore)
+
 A cheminformatics toolkit for Rust.
 
 ChemCore provides primitives for working with Molecules. For details, see: *[ChemCore: A Cheminformatics Toolkit for Rust](https://depth-first.com/articles/2020/06/01/chemcore-a-cheminformatics-toolkit-for-rust/)*.


### PR DESCRIPTION
This adds a couple links to the readme for user convenience.

See https://github.com/bddap/chemcore/tree/links-in-readme for a rendered example.

Thank you for starting this library by the way. Rust needs a cheminformatics toolkit.